### PR TITLE
Introduce lefthook for pre-commit lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,6 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@ Toy implementation of AES and GCM written in Go.
 
 See: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.197.pdf
 
+## Development
+
+CLI tools (`golangci-lint`, `lefthook`) are managed by [aqua](https://aquaproj.github.io/) with versions pinned in [aqua.yaml](aqua.yaml).
+
+### Install tools
+
+Install aqua itself first (see the [aqua installation guide](https://aquaproj.github.io/docs/install)), then install the pinned tools:
+
+```
+aqua install
+```
+
+### Set up git hooks
+
+[lefthook](lefthook.yml) runs `golangci-lint` on staged `*.go` files before each commit. Register the hooks once after cloning:
+
+```
+lefthook install
+```
+
+### Lint
+
+```
+golangci-lint run --enable=gosec
+```
+
 ## Test
 
 ```

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,3 +12,4 @@ registries:
   ref: v4.485.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: golangci/golangci-lint@v2.11.4
+- name: evilmartians/lefthook@v2.1.6

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-commit:
+  parallel: true
+  commands:
+    golangci-lint:
+      glob: "*.go"
+      run: golangci-lint run --enable=gosec


### PR DESCRIPTION
## Summary
- Add lefthook (v2.1.6) via aqua to enforce `golangci-lint` on staged `*.go` before commit
- Mirror the toychacha setup: `.golangci.yaml` enables gofmt/goimports formatters
- Document aqua / lefthook setup steps in README

## Test plan
- [x] `aqua install`
- [x] `lefthook install`
- [x] `lefthook run pre-commit --all-files`